### PR TITLE
Add all hex values of new commands introduced from v1.40 and implementation of setDeviceName 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
 
 setup(
     name='sphero',
-    version='0.0.0',
+    version='0.0.1',
     description='A python client for Sphero.',
     long_description=readme,
     author='Chris Faulkner',

--- a/sphero/request.py
+++ b/sphero/request.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import struct
 import response
 
@@ -32,8 +33,7 @@ class Request(object):
 
     def packet_body(self):
         if not self.data:
-            return ''
-
+            return ''    
         return struct.pack(self.fmt, *self.data)
 
     @property
@@ -52,13 +52,15 @@ class Request(object):
 class Core(Request):
     did = 0x00
 
+
+
 class Ping(Core):
     cid = 0x01
 
 class GetVersion(Core):
     cid = 0x02
 
-class GetDeviceName(Core):
+class SetDeviceName(Core):
     cid = 0x10
 
 class GetBluetoothInfo(Core):
@@ -106,6 +108,8 @@ class SetTimeValue(Core):
 class PollPacketTimes(Core):
     cid = 0x51
 
+
+#Sphero Commands
 
 class Sphero(Request):
     did = 0x02

--- a/sphero/request.py
+++ b/sphero/request.py
@@ -170,6 +170,7 @@ class GetRGB(Sphero):
     cid = 0x22
 
 class Roll(Sphero):
+    fmt = '!BHB' #Speed, heading, state
     cid = 0x30
 
 class SetBoostWithTime(Sphero):

--- a/sphero/request.py
+++ b/sphero/request.py
@@ -138,11 +138,23 @@ class SetChassisId(Sphero):
 class SelfLevel(Sphero):
     cid = 0x09
 
+class SetVDL(Sphero):
+    cid = 0x0A
+
 class SetDataStreaming(Sphero):
     cid = 0x11
 
 class ConfigureCollisionDetection(Sphero):
     cid = 0x12
+
+class Locator(Sphero):
+    cid = 0x13
+
+class SetAccelerometer(Sphero):
+    cid = 0x14
+
+class ReadLocator(Sphero):
+    cid=0x15
 
 class SetRGB(Sphero):
     cid = 0x20
@@ -209,3 +221,6 @@ class RunOrbbasicProgram(Sphero):
 
 class AbortOrbbasicProgram(Sphero):
     cid = 0x63
+
+class AnswerInput(Sphero):
+    cid = 0x64

--- a/sphero/response.py
+++ b/sphero/response.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import struct
 
 


### PR DESCRIPTION
Hi!

Just for a hello-world goal I decided to implement the setDeviceName.
That made me real familiar with the inner mechanics of the API  :). 

Had some trouble with sending strings as data, but solved it with a helper function:

```
  def prep_str(self,s):
      return [ord(c) for c in s]
```

This will yield errors on unicode charracters outside the range of 0-255 (i-e multibyte chars), but that is fine. what we want really.

Also, I added the hex values for all new commands introduced in version 1.40 of the API docs.
- Robin
